### PR TITLE
Ensure foreign_key_alias is in select columns when columns are enumerated because of ignored_columns

### DIFF
--- a/lib/active_record/has_some_of_many/associations.rb
+++ b/lib/active_record/has_some_of_many/associations.rb
@@ -38,7 +38,13 @@ module ActiveRecord
                           .arel.lateral(lateral_table.name)
                       ).on("TRUE")
 
-        relation.klass.from(subselect.as(relation.arel_table.name))
+        select_values = if relation.klass.ignored_columns.any?
+                          [relation.klass.arel_table[foreign_key_alias]] + relation.klass.columns.map { |column| relation.klass.arel_table[column.name] }
+                        else
+                          [relation.klass.arel_table[Arel.star]]
+                        end
+
+        relation.klass.select(select_values).from(subselect.as(relation.arel_table.name))
       end
 
       class_methods do

--- a/test/has_some_of_many_test.rb
+++ b/test/has_some_of_many_test.rb
@@ -99,6 +99,41 @@ class ActiveRecordHasSomeOfManyTest < ActiveSupport::TestCase
     end
   end
 
+  class CommentWithIgnoredColumns < Comment
+    self.ignored_columns = %w[created_at updated_at]
+  end
+
+  class PostHasCommentsWithIgnoredColumns < Post
+    has_some_of_many :last_two_comments, -> { order(created_at: :desc).limit(2) }, class_name: 'CommentWithIgnoredColumns', foreign_key: "post_id"
+  end
+
+  test "Model with ignored columns" do
+    post = PostHasCommentsWithIgnoredColumns.create!
+    10.times do |index|
+      post.comments.create!(body: "Comment #{index + 1}")
+    end
+
+    relation = ActiveRecord::HasSomeOfMany::Associations.build_scope(PostHasCommentsWithIgnoredColumns, CommentWithIgnoredColumns.order(id: :desc), primary_key: "id", foreign_key: "post_id", foreign_key_alias: "post_id_alias", limit: 1)
+    assert_equal relation.to_sql, strip(<<~SQL)
+      SELECT "comments"."post_id_alias", "comments"."id", "comments"."body", "comments"."post_id"
+      FROM (
+        SELECT "posts"."id" AS post_id_alias, "lateral_table".* 
+        FROM "posts" 
+        INNER JOIN LATERAL (
+          SELECT "comments"."id", "comments"."body", "comments"."post_id"
+          FROM "comments" 
+          WHERE "comments"."post_id" = "posts"."id" 
+          ORDER BY "comments"."id" DESC
+          LIMIT 1
+        ) lateral_table ON TRUE
+      ) comments
+    SQL
+
+    PostHasCommentsWithIgnoredColumns.includes(:last_two_comments).each do |post|
+      assert_equal ["Comment 10", "Comment 9"], post.last_two_comments.map(&:body)
+    end
+  end
+
   test ".build_scope" do
     relation = ActiveRecord::HasSomeOfMany::Associations.build_scope(Post, Comment.order(id: :desc), primary_key: "id", foreign_key: "post_id", foreign_key_alias: "post_id_alias", limit: 1)
 


### PR DESCRIPTION
Active Record can't associate the records correctly when eagerloading if the aliased foreign key is not present in the returned rows.