### PR TITLE
Rescope to remove `where`, `order`, and `limit` to fix `in_batches` queries

### DIFF
--- a/lib/active_record/has_some_of_many/associations.rb
+++ b/lib/active_record/has_some_of_many/associations.rb
@@ -29,7 +29,7 @@ module ActiveRecord
 
       def self.build_scope(klass, relation, primary_key:, foreign_key:, foreign_key_alias:, limit: nil)
         lateral_table = Arel::Table.new('lateral_table')
-        subselect = klass.unscope(:select)
+        subselect = klass.unscope(:select, :joins, :where, :order, :limit)
                       .select(klass.arel_table[primary_key].as(foreign_key_alias), lateral_table[Arel.star])
                       .arel.join(
                         relation

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,6 +20,11 @@ DB_CONFIG = if ENV.fetch("DATABASE", "postgresql") == "postgresql"
             end
 
 begin
+  log_file = File.open(File.expand_path("../tmp/test.log", __dir__), "a").tap do |f|
+    f.binmode
+    f.sync = true
+  end
+  ActiveRecord::Base.logger = ActiveSupport::Logger.new(log_file)
   ActiveRecord::Base.establish_connection(DB_CONFIG)
 
   ActiveRecord::Schema.verbose = false


### PR DESCRIPTION
Fixes #4 

`find_in_batches` will add additional WHERE, ORDER AND LIMIT clauses that we strip out via rescope
 
```sql
-- TestHasSomeOfManyPost.where.not(title: nil).includes(:last_two_comments).find_in_batches(batch_size: 5)

SELECT "comments".* FROM (SELECT "posts"."id" AS post_id_alias, "lateral_table".* FROM "posts" INNER JOIN LATERAL (SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = "posts"."id" ORDER BY "comments"."created_at" DESC LIMIT $1)
lateral_table ON TRUE ORDER BY "posts"."id" ASC LIMIT $2) comments WHERE "comments"."post_id_alias" IN ($3, $4)
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```