### PR TITLE
Support self-referencing relations where the children are the same model as the parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This gem adds new optimized Active Record association methods (`has_one_of_many`, `has_some_of_many`) for "top N" queries to ActiveRecord using `JOIN LATERAL` that are eager-loadable (`includes(:association)`, `preloads(:association)`) to avoid N+1 queries, and is compatible with typical queries and batch methods (`find_each`, `in_batches`, `find_in_batches`). For example, you might have these types of queries in your application:
 
-- Users have many posts, and you want to query the most recent post for each user 
+- Users have many posts, and you want to query the most recent post for each user
 - Posts have many comments, and you want to query the 5 most recent visible comments for each post
 - Posts have many comments, and you want to query the one comment with the largest `votes_count` for each post
 
@@ -10,9 +10,13 @@ You can read more about these types of queries on [Benito Serna's "Fetching the 
 
 ## Compatibility
 
-This gem is only compatible with databases that offer `LATERAL` joins within Active Record. As far as I'm aware, that is **only Postgres**. 
+This gem is only compatible with databases that offer `LATERAL` joins within Active Record. As far as I'm aware, that is **only Postgres**.
 
 This gem is not necessary on SQLite, as SQLite will perform lateral-like behavior on join queries by default. MySQL has support for lateral queries, but they are not yet implemented in Active Record.
+
+**Really complex queries may not work; please open an issue!** This library works by rewriting Active Record queries; it's possible to create some very complex queries with Active Record. Some things that are specifically known to work:
+  - Model associations to the same model. It works.
+  - _Please help expand this list by opening an issue if you find something that doesn't work!_
 
 ## Usage
 
@@ -50,10 +54,10 @@ add_index :comments, [:post_id, :votes_count]
 
 ## Why?
 
-Finding the "Top N" is a common problem, that can be easily solved with a `JOIN LATERAL` when writing raw SQL queries. Lateral Joins were introduced in Postgres 9.3: 
+Finding the "Top N" is a common problem, that can be easily solved with a `JOIN LATERAL` when writing raw SQL queries. Lateral Joins were introduced in Postgres 9.3:
 
 > a LATERAL join is like a SQL foreach loop, in which Postgres will iterate over each row in a result set and evaluate a subquery using that row as a parameter. ([source](https://www.heap.io/blog/postgresqls-powerful-new-join-type-lateral))
- 
+
 For example, to find only the one most recent comments for a collection of posts, we might write:
 
 ```sql

--- a/lib/activerecord-has_some_of_many.rb
+++ b/lib/activerecord-has_some_of_many.rb
@@ -5,5 +5,7 @@ require_relative "activerecord/has_some_of_many/version"
 
 ActiveSupport.on_load(:active_record) do
   require_relative "activerecord/has_some_of_many/associations"
+  require_relative "activerecord/has_some_of_many/relation_rewriter"
+
   include ActiveRecord::HasSomeOfMany::Associations
 end

--- a/lib/activerecord/has_some_of_many/associations.rb
+++ b/lib/activerecord/has_some_of_many/associations.rb
@@ -33,7 +33,8 @@ module ActiveRecord
                       .select(klass.arel_table[primary_key].as(foreign_key_alias), lateral_table[Arel.star])
                       .arel.join(
                         relation
-                          .where(relation.arel_table[foreign_key].eq(klass.arel_table[primary_key]))
+                          .then { |query| relation.table.name == klass.arel_table.name ? ActiveRecord::HasSomeOfMany::RelationRewriter.new(query).alias_table("#{klass.table_name}__alias") : query }
+                          .then { |query| query.where(query.table[foreign_key].eq(klass.arel_table[primary_key])) }
                           .then { |query| limit ? query.limit(limit) : query }
                           .arel.lateral(lateral_table.name)
                       ).on("TRUE")

--- a/lib/activerecord/has_some_of_many/relation_rewriter.rb
+++ b/lib/activerecord/has_some_of_many/relation_rewriter.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module HasSomeOfMany
+    class RelationRewriter
+      def initialize(relation)
+        @relation = relation
+      end
+
+      def alias_table(alias_name)
+        relation_class = @relation.klass
+        original_table = relation_class.arel_table
+        alias_table = original_table.alias(alias_name)
+
+        where_clause = recursively_alias_table(@relation.where_clause.ast, original_table, alias_table)
+        order_clause = @relation.order_values.map do |order|
+          if order.respond_to?(:expr)
+            order.expr = alias_table[order.expr.name] if order.expr.relation == original_table
+          end
+          order
+        end
+
+        new_relation = @relation.dup.unscope(:select, :where, :order)
+        new_relation.instance_variable_set(:@table, alias_table) # Is there a better way to modify the original relation?
+        new_relation.where(where_clause).order(order_clause)
+      end
+
+      def recursively_alias_table(node, original_table, alias_table)
+        case node
+        when Arel::Nodes::And, Arel::Nodes::Or
+          return nil if node.children.empty?
+
+          # Recurse for left and right nodes
+          node.children.each { |child| recursively_alias_table(child, original_table, alias_table) }
+          node
+        when Arel::Nodes::Grouping
+          # Recurse for the expression inside the grouping
+          node.expr = recursively_alias_table(node.expr, original_table, alias_table)
+          node
+        when Arel::Nodes::Equality, Arel::Nodes::GreaterThan, Arel::Nodes::LessThan, Arel::Nodes::HomogeneousIn
+          # For conditions, modify left-hand side (the column)
+          if node.left.relation == original_table
+            node.left.relation = alias_table
+          end
+          node
+        else
+          node
+        end
+      end
+    end
+  end
+end

--- a/test/relation_rewriter_test.rb
+++ b/test/relation_rewriter_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RelationRewriterTest < ActiveSupport::TestCase
+  include ActiveRecord::Assertions::QueryAssertions
+  include SQLTestHelpers
+
+  def setup
+    Leaf.delete_all
+  end
+
+  test "#alias_table" do
+    relation = Leaf.where(id: [1, 2]).or(Leaf.where(published: true)).order(created_at: :desc)
+    new_relation = ActiveRecord::HasSomeOfMany::RelationRewriter.new(relation).alias_table("omg_leafs")
+
+    assert_equal "omg_leafs", new_relation.table.name
+    assert_sql(<<~SQL, new_relation.to_sql)
+      SELECT "omg_leafs".*
+      FROM "leafs" "omg_leafs"
+      WHERE ("omg_leafs"."id" IN (1, 2) OR "omg_leafs"."published" = TRUE)
+      ORDER BY "omg_leafs"."created_at" DESC
+    SQL
+  end
+
+  test "#alias_table without where clause" do
+
+    relation = Leaf.order(created_at: :desc).limit(2)
+    new_relation = ActiveRecord::HasSomeOfMany::RelationRewriter.new(relation).alias_table("omg_leafs")
+
+    assert_sql(<<~SQL, new_relation.to_sql)
+      SELECT "omg_leafs".*
+      FROM "leafs" "omg_leafs"
+      ORDER BY "omg_leafs"."created_at" DESC
+      LIMIT 2
+    SQL
+  end
+end
+
+

--- a/test/support/sql_test_helpers.rb
+++ b/test/support/sql_test_helpers.rb
@@ -1,0 +1,10 @@
+module SQLTestHelpers
+  def assert_sql(expected, actual, msg = nil)
+    expected = strip_sql(expected)
+    actual = strip_sql(actual)
+    assert_equal expected, actual, msg
+  end
+  def strip_sql(sql)
+    sql.squish.gsub(/\s+/, " ").gsub(" ( ", " (").gsub(" ) ", ") ")
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require 'active_record'
 require 'activerecord-has_some_of_many'
 
 require_relative "support/active_record_query_assertions"
+require_relative "support/sql_test_helpers"
 
 DB_CONFIG = if ENV.fetch("DATABASE", "postgresql") == "postgresql"
               {
@@ -40,6 +41,14 @@ begin
       t.references :post, index: false
       t.index [:post_id, :created_at]
     end
+
+    create_table :leafs, force: true do |t|
+      t.timestamps
+      t.boolean :published
+      t.string :name
+      t.bigint :parent_id
+      t.index [:parent_id, :created_at]
+    end
   end
 rescue ActiveRecord::NoDatabaseError
   raise if retried ||= nil
@@ -58,4 +67,9 @@ end
 
 class Comment < ActiveRecord::Base
   belongs_to :post
+end
+
+class Leaf < ActiveRecord::Base
+  belongs_to :parent, class_name: "Leaf", foreign_key: "parent_id", optional: true
+  has_many :children, class_name: "Leaf", foreign_key: "parent_id"
 end


### PR DESCRIPTION
Fixes #8 

I do wonder if there is a better/simpler way to rewrite the relation's table alias to update all of the previously existing scopes. 